### PR TITLE
set up proper .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-detectable=false
+*.go linguist-detectable=true


### PR DESCRIPTION
## Summary
- set up proper .gitattributes to keep GitHub language stats focused on primary project language(s).