### PR TITLE
upgrade toolchain to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhth/dstll
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/ui/initial.go
+++ b/ui/initial.go
@@ -20,7 +20,7 @@ func InitialModel(config Config) Model {
 	var unsupportedFTMsg strings.Builder
 	unsupportedFTMsg.WriteString("dstll will show constructs for the following file types:\n")
 	for _, ft := range supportedFT {
-		unsupportedFTMsg.WriteString(fmt.Sprintf("%s\n", ft))
+		fmt.Fprintf(&unsupportedFTMsg, "%s\n", ft)
 	}
 
 	fpWidth := 40


### PR DESCRIPTION
## Summary
- upgrade the Go toolchain from 1.26.1 to 1.26.2
- replace WriteString(fmt.Sprintf(...)) with fmt.Fprintf to satisfy staticcheck on the newer toolchain/lint path